### PR TITLE
ci: add HOL skill-publish validate workflow

### DIFF
--- a/.github/workflows/hol-skill-validate.yml
+++ b/.github/workflows/hol-skill-validate.yml
@@ -1,0 +1,28 @@
+name: HOL Skill Validate
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Validate Skill
+        uses: hashgraph-online/skill-publish@96e6eb1e52ba479d15067aef9dde83ca94afb06a
+        with:
+          mode: validate


### PR DESCRIPTION
I opened this because <h1 align="center">🏛️ European Parliament MCP Server</h1>.

What stood out from the repo:
- <h1 align="center">🏛️ European Parliament MCP Server</h1>
- <strong>Model Context Protocol Server for European Parliament Open Data</strong><br>
- <em>Providing AI assistants with structured access to parliamentary datasets and OSINT Intelligence Capabilities</em>

This adds a validate-only workflow that runs the HOL skill validator on this repository. It checks schema and trust signals only, stays validate-only, and leaves runtime code alone.

If you'd like a different workflow path, I can adjust the branch.