### PR TITLE
feat: improve skill scores for European-Parliament-MCP-Server

### DIFF
--- a/.github/skills/european-parliament-api/SKILL.md
+++ b/.github/skills/european-parliament-api/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: european-parliament-api
-description: European Parliament API integration patterns, data source navigation, response validation, and cache optimization
+description: "Queries European Parliament API endpoints to fetch legislative documents, MEP profiles, voting records, and committee data with caching and rate limiting. Use when integrating EP Open Data Portal, fetching EU parliamentary data, accessing Europarl endpoints, or configuring API caching strategies."
 license: MIT
 ---
 
@@ -10,15 +10,10 @@ license: MIT
 
 This skill applies when:
 - Integrating with European Parliament Open Data Portal API
-- Fetching MEP, plenary, committee, document, or question data
-- Implementing API caching strategies
-- Handling rate limits and retries
-- Validating European Parliament data structures
-- Supporting multilingual data (24 EU languages)
-- Ensuring GDPR compliance for personal data
-- Adding proper data attribution
-
-The European Parliament Open Data Portal (`data.europarl.europa.eu`) is the authoritative source for all parliamentary data accessed through this MCP server.
+- Fetching MEP profiles, plenary sessions, committee data, or legislative documents
+- Configuring API caching, rate limiting, or retry strategies
+- Validating EP API responses or handling multilingual data (24 EU languages)
+- Adding EP source attribution or ensuring GDPR compliance
 
 ## Rules
 
@@ -33,6 +28,14 @@ The European Parliament Open Data Portal (`data.europarl.europa.eu`) is the auth
 9. **Log API Access**: Log all European Parliament API calls for audit
 10. **Support GDPR**: Implement data minimization and cache time limits
 
+## Workflow
+
+1. Initialize API client with `User-Agent` header and base URL (`https://data.europarl.europa.eu/api/v2/`)
+2. Configure rate limiter (60 req/min) — check burst limits before each request
+3. Set up caches with TTLs per data type (MEPs: 1h, documents: 6h, votes: 24h)
+4. Make request through rate limiter → validate response with Zod schema → add attribution
+5. Return cached result on subsequent calls; purge stale entries hourly
+
 ## Examples
 
 ### ✅ Good Pattern: API Client with Caching
@@ -40,21 +43,16 @@ The European Parliament Open Data Portal (`data.europarl.europa.eu`) is the auth
 ```typescript
 import { LRUCache } from 'lru-cache';
 
-// Cache configuration by data type
 const mepCache = new LRUCache<string, MEP>({
   max: 1000,
   ttl: 1000 * 60 * 60, // 1 hour
 });
 
-// Fetch MEP with caching
 async function getMEP(id: number): Promise<MEP> {
   const cacheKey = `mep:${id}`;
-  
-  // Check cache
   const cached = mepCache.get(cacheKey);
   if (cached) return cached;
-  
-  // Fetch from API
+
   const response = await fetch(
     `https://data.europarl.europa.eu/api/v2/meps/${id}`,
     {
@@ -64,16 +62,13 @@ async function getMEP(id: number): Promise<MEP> {
       },
     }
   );
-  
+
   if (!response.ok) {
     throw new APIError(`EP API error: ${response.status}`);
   }
-  
+
   const mep = await response.json();
-  
-  // Cache result
   mepCache.set(cacheKey, mep);
-  
   return mep;
 }
 ```
@@ -104,10 +99,8 @@ const rateLimiter = new EPAPIRateLimiter();
 
 async function fetchFromEP(url: string): Promise<Response> {
   await rateLimiter.waitForSlot();
-  
   const response = await fetch(url);
-  
-  // Handle rate limit
+
   if (response.status === 429) {
     const retryAfter = response.headers.get('Retry-After');
     const waitTime = retryAfter ? parseInt(retryAfter) * 1000 : 60000;
@@ -144,23 +137,9 @@ interface Attribution {
 
 ## Anti-Patterns
 
-### ❌ Bad: No Rate Limiting
-```typescript
-// NEVER - will hit rate limits!
-async function bad() {
-  const promises = ids.map(id => fetch(`https://data.europarl.europa.eu/api/v2/meps/${id}`));
-  return await Promise.all(promises); // Too many concurrent requests!
-}
-```
-
-### ❌ Bad: No Attribution
-```typescript
-// NEVER - violates EP terms of use!
-async function bad() {
-  const data = await fetchFromEP(url);
-  return data; // Missing source attribution!
-}
-```
+- **No rate limiting**: Do not fire unbounded `Promise.all` against EP endpoints — always route through the rate limiter.
+- **Missing attribution**: Every response must include EP source attribution; omitting it violates terms of use.
+- **Unbounded caches**: Always set `max` size and `ttl` on caches to avoid memory leaks and stale data.
 
 ## ISMS Compliance
 

--- a/.github/skills/gdpr-compliance/SKILL.md
+++ b/.github/skills/gdpr-compliance/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gdpr-compliance
-description: GDPR and data protection patterns for handling European Parliament personal data with privacy by design
+description: "Enforces GDPR data protection for European Parliament personal data — data minimization, audit logging, cache TTL limits, and data subject rights (access, rectification, erasure). Use when processing MEP personal data, implementing privacy controls, handling data subject requests, conducting a DPIA, applying PII anonymization, or configuring cache retention policies."
 license: MIT
 ---
 
@@ -11,14 +11,13 @@ license: MIT
 This skill applies when:
 - Processing personal data from European Parliament (MEP information)
 - Implementing data minimization strategies
-- Supporting GDPR rights (access, rectification, erasure)
-- Implementing audit logging for personal data access
+- Supporting data subject rights: access, rectification, erasure, consent withdrawal
+- Implementing audit logging for PII and personal data access
 - Designing privacy-by-design features
 - Handling data retention and deletion
 - Implementing consent mechanisms
-- Creating data protection impact assessments
-
-GDPR (EU Regulation 2016/679) applies to all processing of EU citizens' personal data. Even though MEP data is public, GDPR principles still apply.
+- Creating data protection impact assessments (DPIA)
+- Applying anonymization or pseudonymization to personal data
 
 ## Rules
 
@@ -33,32 +32,35 @@ GDPR (EU Regulation 2016/679) applies to all processing of EU citizens' personal
 9. **Data Protection by Design**: Build privacy into architecture
 10. **Transparency**: Document all data processing activities
 
+## Workflow
+
+1. Define minimal data interface — include only public parliamentary fields (name, country, party, active status), exclude private data
+2. Implement audit logging for all personal data access (GDPR Art. 30) — every read, write, and delete must be recorded
+3. Configure cache with TTL (max 24h for personal data) and hourly stale-entry purge
+4. Add data subject rights handlers: access (Art. 15), rectification (Art. 16), erasure (Art. 17)
+5. Conduct a DPIA if introducing new processing activities or changing data flows
+6. Verify: confirm audit logs capture every access path, cache entries expire correctly, and no PII leaks into unprotected stores
+
 ## Examples
 
 ### ✅ Good Pattern: Data Minimization
 
 ```typescript
-// GOOD: Only public information
 interface MEPPublicData {
   id: number;
   fullName: string;
   country: string;
   partyGroup: string;
   active: boolean;
-  // DO NOT collect: private addresses, personal phones, family data
 }
 
-// Define data purpose
 const DATA_PURPOSE = 'Providing public parliamentary information via MCP protocol';
 ```
 
 ### ✅ Good Pattern: Audit Logging
 
 ```typescript
-/**
- * GDPR-compliant audit logging
- * Requirement: GDPR Art. 30 (Records of processing activities)
- */
+/** GDPR Art. 30 — Records of processing activities */
 function logPersonalDataAccess(
   actor: string,
   subject: string,
@@ -74,7 +76,6 @@ function logPersonalDataAccess(
   });
 }
 
-// Usage
 logPersonalDataAccess(
   'mcp_client',
   'mep:12345',
@@ -85,23 +86,15 @@ logPersonalDataAccess(
 ### ✅ Good Pattern: Right to Rectification
 
 ```typescript
-/**
- * Support GDPR Art. 16 (Right to rectification)
- */
+/** GDPR Art. 16 — Right to rectification */
 async function updateMEPData(
   id: number,
   corrections: Partial<MEP>
 ): Promise<void> {
-  // Validate corrections
   const validated = MEPUpdateSchema.parse(corrections);
-  
-  // Update data
   await updateMEP(id, validated);
-  
-  // Invalidate cache
   invalidateMEPCache(id);
-  
-  // Audit log
+
   auditLog.record({
     eventType: 'data_rectification',
     subject: `mep:${id}`,
@@ -115,50 +108,23 @@ async function updateMEPData(
 ### ✅ Good Pattern: Storage Limitation
 
 ```typescript
-/**
- * GDPR Art. 5(1)(e): Storage limitation
- * Personal data cached for max 24 hours
- */
+/** GDPR Art. 5(1)(e) — Personal data cached for max 24 hours */
 const mepCache = new LRUCache<string, MEP>({
   max: 1000,
-  ttl: 1000 * 60 * 60 * 24, // 24 hours max
+  ttl: 1000 * 60 * 60 * 24,
   allowStale: false,
 });
 
-// Auto-purge expired entries
 setInterval(() => {
   mepCache.purgeStale();
-}, 1000 * 60 * 60); // Hourly cleanup
+}, 1000 * 60 * 60);
 ```
 
 ## Anti-Patterns
 
-### ❌ Bad: No Audit Logging
-```typescript
-// NEVER - GDPR requires audit logs!
-async function bad(mepId: number) {
-  return await getMEP(mepId); // No logging!
-}
-```
-
-### ❌ Bad: Excessive Data Collection
-```typescript
-// NEVER - violates data minimization!
-interface MEPBad {
-  id: number;
-  fullName: string;
-  privateAddress: string;      // Excessive!
-  personalPhone: string;        // Excessive!
-  familyMembers: string[];      // Excessive!
-  medicalRecords: string;       // Excessive!
-}
-```
-
-### ❌ Bad: Indefinite Storage
-```typescript
-// NEVER - violates storage limitation!
-const cache = new Map(); // No TTL = indefinite storage!
-```
+- **Never** access personal data without audit logging — every `getMEP()` call must be recorded
+- **Never** collect private addresses, personal phones, family data, or medical records (data minimization)
+- **Never** store personal data in a cache without TTL — use max 24h with `allowStale: false`
 
 ## GDPR Rights Implementation
 
@@ -178,11 +144,10 @@ async function getPersonalData(mepId: number): Promise<PersonalDataExport> {
 ### Right to Erasure (Art. 17)
 ```typescript
 async function handleErasureRequest(mepId: number): Promise<ErasureResult> {
-  // For current MEPs: Cannot erase (public interest exemption)
-  // CAN erase: Cached personal contact information
-  
+  // Current MEPs: public interest exemption (Art. 17(3)(e))
+  // Cached personal contact info: eligible for erasure
   invalidateMEPCache(mepId);
-  
+
   return {
     success: true,
     scope: 'cached_data_only',

--- a/.github/skills/mcp-server-development/SKILL.md
+++ b/.github/skills/mcp-server-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mcp-server-development
-description: MCP protocol patterns, tool implementation, resource handlers, prompt templates, and error handling for Model Context Protocol servers
+description: "Implements MCP tool handlers with Zod validation, defines resource endpoints with URI patterns, and creates prompt templates for the European Parliament MCP server. Use when building MCP tools, registering resources, designing prompts, or debugging Model Context Protocol integrations."
 license: MIT
 ---
 
@@ -18,20 +18,22 @@ This skill applies when:
 - Testing MCP server implementations
 - Optimizing MCP tool performance
 
-MCP (Model Context Protocol) is the foundation of this server. All data access must follow MCP specification patterns to ensure compatibility with MCP clients.
-
 ## Rules
 
-1. **Follow MCP Specification**: Implement all handlers according to [MCP protocol specification](https://spec.modelcontextprotocol.io/)
-2. **Validate Tool Inputs**: Use Zod schemas to validate all tool inputs before processing
-3. **Return Structured Responses**: Always return MCP-compliant response structures with `content` array
-4. **Handle Errors Gracefully**: Catch errors and return safe error messages (never expose internal details)
-5. **Use Type Safety**: Leverage TypeScript types for all MCP handlers and request/response objects
-6. **Implement Resources with URIs**: Use consistent URI patterns (e.g., `ep://meps/{id}`)
-7. **Provide Tool Descriptions**: Write clear, concise descriptions for all tools, resources, and prompts
-8. **Document Input Schemas**: Use JSON Schema in tool listings to document expected inputs
-9. **Log MCP Operations**: Log all tool invocations, resource accesses for audit trails
-10. **Test MCP Handlers**: Write comprehensive tests for all MCP tools and resources
+1. **Follow MCP Specification**: Implement all handlers according to [MCP protocol specification](https://spec.modelcontextprotocol.io/) — use `ListToolsRequestSchema`, `CallToolRequestSchema`, `ListResourcesRequestSchema`, and `ReadResourceRequestSchema` from `@modelcontextprotocol/sdk`
+2. **Validate Tool Inputs with Zod**: Define a `.strict()` Zod schema for every tool's arguments and call `.parse()` before any processing to reject unknown fields
+3. **Return Structured Responses**: Always return `{ content: [{ type: "text", text: string }] }` for tools and `{ contents: [{ uri, mimeType, text }] }` for resources
+4. **Handle Errors Gracefully**: Catch errors, log them internally with `console.error`, and re-throw a safe user-facing message via `throw new Error('...')` — never expose stack traces or internal details
+5. **Implement Resources with URI Patterns**: Use consistent URI templates (e.g., `ep://meps/{id}`, `ep://committees/{code}`) and validate URIs with regex before parsing
+6. **Provide Tool Descriptions**: Write clear, action-oriented descriptions for every tool, resource, and prompt so MCP clients can discover and present them accurately
+
+## Workflow
+
+1. Define a Zod input schema with `.strict()` to reject unknown fields
+2. Register the tool via `server.setRequestHandler(ListToolsRequestSchema, ...)` with name, description, and JSON Schema
+3. Implement the handler: parse input with Zod → fetch/process data → wrap result in `{ content: [{ type: "text", text }] }`
+4. Add error handling: catch errors, log internally with `console.error`, return safe message via `throw new Error('...')`
+5. Verify registration with `server.listTools()` and test with sample inputs
 
 ## Examples
 
@@ -122,26 +124,10 @@ server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
 
 ## Anti-Patterns
 
-### ❌ Bad: No Input Validation
-```typescript
-// NEVER - no validation!
-async function bad(request: any) {
-  const data = await fetch(request.params.arguments.url); // Injection risk!
-  return { content: [{ type: "text", text: data }] };
-}
-```
-
-### ❌ Bad: Exposing Internal Errors
-```typescript
-// NEVER - exposes internals!
-async function bad(request: any) {
-  try {
-    return await process(request);
-  } catch (error) {
-    throw error; // Exposes stack trace!
-  }
-}
-```
+- **No input validation**: Never use `request.params.arguments` directly without Zod parsing — risks injection and malformed data
+- **Exposing internal errors**: Never re-throw raw errors (`throw error`) — wrap them in a safe message to avoid leaking stack traces
+- **Missing content wrapper**: Never return plain strings — always wrap in `{ content: [{ type: "text", text }] }`
+- **Hardcoded resource URIs**: Never skip URI validation with regex before parsing resource identifiers
 
 ## ISMS Compliance
 

--- a/.github/skills/security-by-design/SKILL.md
+++ b/.github/skills/security-by-design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: security-by-design
-description: API security, MCP tool security, input validation, rate limiting, audit logging, secure authentication, and defense-in-depth principles
+description: "Enforces defense-in-depth security for MCP tools and European Parliament APIs — input validation, rate limiting, audit logging, and secure error handling. Use when implementing API security, adding authentication, protecting MCP endpoints, or reviewing code for vulnerabilities."
 license: MIT
 ---
 
@@ -11,917 +11,115 @@ This skill applies when:
 - Implementing MCP protocol tools and handlers
 - Exposing European Parliament data through APIs
 - Handling user inputs or external data sources
-- Implementing authentication or authorization mechanisms
-- Processing sensitive or classified information
+- Implementing auth, OAuth, API keys, or secure endpoints
 - Designing rate limiting or abuse prevention
 - Implementing audit logging and monitoring
-- Writing security-critical validation logic
 - Handling errors and exceptions securely
-- Configuring network security or TLS
 
-Security is foundational, not optional. Every feature must be designed with security in mind from the start, following the principle of "secure by default" and implementing defense-in-depth strategies aligned with Hack23 AB's ISMS policies.
+Security is foundational, not optional. Every feature must be designed with security in mind from the start, following "secure by default" principles and defense-in-depth strategies aligned with Hack23 AB's ISMS policies.
 
 ## Rules
 
-1. **Never Trust Input**: Validate and sanitize all user inputs - treat everything as potentially malicious
-2. **Fail Securely**: Systems must fail to a secure state, never expose sensitive information in errors
-3. **Principle of Least Privilege**: Grant minimal permissions required for functionality, nothing more
-4. **Defense in Depth**: Implement multiple overlapping security controls (validation + rate limiting + audit logging)
-5. **Encrypt Everything**: Use TLS 1.3+ for transit, AES-256 for at rest, never store secrets in plaintext
-6. **Audit All Actions**: Log authentication attempts, authorization failures, input validation errors
-7. **Rate Limit Aggressively**: Protect against abuse, DoS attacks, and resource exhaustion
-8. **Validate Schema**: Use strict schema validation for all MCP tool inputs and outputs
-9. **Sanitize Output**: Encode data appropriately to prevent injection attacks (XSS, command injection)
-10. **Secure Defaults**: All features must be secure by default, require opt-in for permissive settings
-11. **No Secrets in Code**: Never commit API keys, tokens, or credentials to source control
-12. **Regular Updates**: Keep dependencies updated, scan for vulnerabilities continuously
-13. **Assume Breach**: Design systems assuming attackers will get in - limit blast radius
-14. **Document Security**: Reference ISMS policies, document threat models and security controls
-15. **Test Security**: Write tests for authentication, authorization, input validation, and error handling
+1. **Never Trust Input**: Validate and sanitize all inputs with Zod schemas — treat everything as potentially malicious
+2. **Fail Securely**: Systems must fail to a secure state; never expose sensitive information in errors
+3. **Least Privilege**: Grant minimal permissions required for functionality, nothing more
+4. **Defense in Depth**: Layer multiple security controls (validation + rate limiting + audit logging)
+5. **Rate Limit Aggressively**: Protect against abuse, DoS attacks, and resource exhaustion with burst and sustained limits
+6. **Validate Schema**: Use `.strict()` Zod schemas for all MCP tool inputs — reject unknown fields
+7. **Sanitize Output**: Encode data appropriately to prevent injection attacks (XSS, command injection)
+8. **No Secrets in Code**: Never commit API keys, tokens, or credentials — use environment variables
+
+## Workflow
+
+1. Validate all inputs with Zod schemas and whitelist patterns — reject unknown fields with `.strict()`
+2. Check rate limits (burst: 10 req/10s, sustained: 100 req/15min) before processing
+3. Authorize the request — apply least-privilege access checks
+4. Execute the MCP tool handler
+5. Sanitize output — encode data, strip internal details from errors
+6. Audit log the operation (actor, action, resource, outcome, timestamp)
 
 ## Examples
 
-### ✅ Good Pattern: Comprehensive Input Validation
+### ✅ Good Pattern: Input Validation with Zod
 
 ```typescript
-/**
- * Input validation service for MCP tool parameters
- * 
- * Security controls:
- * - Whitelist validation (only allow known-good patterns)
- * - Length limits to prevent buffer overflow or DoS
- * - Type checking to prevent type confusion
- * - Character set restrictions to prevent injection
- * - Sanitization to remove dangerous content
- * 
- * ISMS Policy: SC-002 (Secure Coding Standards)
- * Compliance: OWASP Top 10 (A03:2021 - Injection), ISO 27001:2022 A.8.3
- * 
- * @security Defense: SQL injection, XSS, command injection, path traversal
- */
-export class InputValidationService {
-  private readonly MAX_KEYWORD_LENGTH = 200;
-  private readonly MAX_DOCUMENT_ID_LENGTH = 50;
-  private readonly MAX_ARRAY_SIZE = 100;
-  
-  // Whitelist: Only alphanumeric, spaces, hyphens, underscores
-  private readonly SAFE_KEYWORD_PATTERN = /^[a-zA-Z0-9\s\-_]+$/;
-  
-  // European Parliament document ID format: EP-YYYYMMDD-NNNNN
-  private readonly DOCUMENT_ID_PATTERN = /^EP-\d{8}-\d{5}$/;
-  
-  // ISO 8601 date format: YYYY-MM-DD
-  private readonly DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
-  
-  // Allowed document types (whitelist)
-  private readonly ALLOWED_DOCUMENT_TYPES = new Set([
-    'REPORT',
-    'RESOLUTION',
-    'DECISION',
-    'DIRECTIVE',
-    'REGULATION',
-    'OPINION',
-  ]);
-  
-  /**
-   * Validate search query parameters
-   * Throws ValidationError with safe error message (no input echoing)
-   */
-  validateSearchQuery(params: unknown): ValidatedSearchQuery {
-    if (typeof params !== 'object' || params === null) {
-      throw new ValidationError('Invalid parameters object');
-    }
-    
-    const query = params as Record<string, unknown>;
-    
-    return {
-      keywords: this.validateKeywords(query.keywords),
-      documentType: this.validateDocumentType(query.documentType),
-      dateFrom: this.validateDate(query.dateFrom, 'dateFrom'),
-      dateTo: this.validateDate(query.dateTo, 'dateTo'),
-      limit: this.validateLimit(query.limit),
-    };
-  }
-  
-  /**
-   * Validate search keywords
-   * Defense: SQL injection, XSS, command injection
-   */
-  private validateKeywords(value: unknown): string {
-    if (typeof value !== 'string') {
-      throw new ValidationError('Keywords must be a string');
-    }
-    
-    const trimmed = value.trim();
-    
-    // Length check (DoS prevention)
-    if (trimmed.length === 0) {
-      throw new ValidationError('Keywords cannot be empty');
-    }
-    
-    if (trimmed.length > this.MAX_KEYWORD_LENGTH) {
-      throw new ValidationError(
-        `Keywords exceed maximum length of ${this.MAX_KEYWORD_LENGTH} characters`
-      );
-    }
-    
-    // Whitelist validation (injection prevention)
-    if (!this.SAFE_KEYWORD_PATTERN.test(trimmed)) {
-      throw new ValidationError(
-        'Keywords contain invalid characters. Only alphanumeric, spaces, hyphens, and underscores are allowed.'
-      );
-    }
-    
-    // Additional sanitization: Remove multiple spaces
-    return trimmed.replace(/\s+/g, ' ');
-  }
-  
-  /**
-   * Validate document type
-   * Defense: Enumeration attacks, injection
-   */
-  private validateDocumentType(value: unknown): string | undefined {
-    if (value === undefined || value === null) {
-      return undefined;
-    }
-    
-    if (typeof value !== 'string') {
-      throw new ValidationError('Document type must be a string');
-    }
-    
-    const normalized = value.trim().toUpperCase();
-    
-    // Whitelist validation
-    if (!this.ALLOWED_DOCUMENT_TYPES.has(normalized)) {
-      throw new ValidationError(
-        `Invalid document type. Allowed types: ${Array.from(this.ALLOWED_DOCUMENT_TYPES).join(', ')}`
-      );
-    }
-    
-    return normalized;
-  }
-  
-  /**
-   * Validate date parameter
-   * Defense: Format string injection, logic errors
-   */
-  private validateDate(value: unknown, field: string): string | undefined {
-    if (value === undefined || value === null) {
-      return undefined;
-    }
-    
-    if (typeof value !== 'string') {
-      throw new ValidationError(`${field} must be a string`);
-    }
-    
-    // Format validation
-    if (!this.DATE_PATTERN.test(value)) {
-      throw new ValidationError(
-        `${field} must be in ISO 8601 format (YYYY-MM-DD)`
-      );
-    }
-    
-    // Semantic validation
-    const date = new Date(value);
-    if (isNaN(date.getTime())) {
-      throw new ValidationError(`${field} is not a valid date`);
-    }
-    
-    // Range validation (European Parliament established 1952)
-    const minDate = new Date('1952-01-01');
-    const maxDate = new Date();
-    maxDate.setDate(maxDate.getDate() + 1); // Allow tomorrow for timezone issues
-    
-    if (date < minDate || date > maxDate) {
-      throw new ValidationError(
-        `${field} must be between 1952-01-01 and today`
-      );
-    }
-    
-    return value;
-  }
-  
-  /**
-   * Validate result limit
-   * Defense: DoS, resource exhaustion
-   */
-  private validateLimit(value: unknown): number {
-    if (value === undefined || value === null) {
-      return 20; // Safe default
-    }
-    
-    const num = Number(value);
-    
-    // Type check
-    if (!Number.isFinite(num)) {
-      throw new ValidationError('Limit must be a valid number');
-    }
-    
-    // Integer check
-    if (!Number.isInteger(num)) {
-      throw new ValidationError('Limit must be an integer');
-    }
-    
-    // Range check (DoS prevention)
-    if (num < 1 || num > 100) {
-      throw new ValidationError('Limit must be between 1 and 100');
-    }
-    
-    return num;
-  }
-  
-  /**
-   * Validate document ID
-   * Defense: Path traversal, injection, enumeration
-   */
-  validateDocumentId(value: unknown): string {
-    if (typeof value !== 'string') {
-      throw new ValidationError('Document ID must be a string');
-    }
-    
-    const trimmed = value.trim();
-    
-    // Length check
-    if (trimmed.length > this.MAX_DOCUMENT_ID_LENGTH) {
-      throw new ValidationError('Document ID exceeds maximum length');
-    }
-    
-    // Format validation (strict whitelist)
-    if (!this.DOCUMENT_ID_PATTERN.test(trimmed)) {
-      throw new ValidationError(
-        'Invalid document ID format. Expected: EP-YYYYMMDD-NNNNN'
-      );
-    }
-    
-    return trimmed;
-  }
-  
-  /**
-   * Validate array parameter
-   * Defense: DoS via large arrays
-   */
-  validateArray<T>(
-    value: unknown,
-    validator: (item: unknown) => T,
-    maxSize: number = this.MAX_ARRAY_SIZE
-  ): T[] {
-    if (!Array.isArray(value)) {
-      throw new ValidationError('Value must be an array');
-    }
-    
-    // Size check (DoS prevention)
-    if (value.length === 0) {
-      throw new ValidationError('Array cannot be empty');
-    }
-    
-    if (value.length > maxSize) {
-      throw new ValidationError(
-        `Array size exceeds maximum of ${maxSize} items`
-      );
-    }
-    
-    // Validate each item
-    return value.map((item, index) => {
-      try {
-        return validator(item);
-      } catch (error) {
-        throw new ValidationError(
-          `Invalid item at index ${index}: ${(error as Error).message}`
-        );
-      }
-    });
-  }
-}
+const SearchQuerySchema = z.object({
+  keywords: z.string().min(1).max(200).regex(/^[a-zA-Z0-9\s\-_]+$/),
+  documentType: z.enum(['REPORT', 'RESOLUTION', 'DECISION', 'DIRECTIVE', 'REGULATION', 'OPINION']).optional(),
+  dateFrom: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+  dateTo: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+  limit: z.number().int().min(1).max(100).default(20),
+}).strict();
 
-/**
- * Custom error class that never exposes user input
- * Prevents information leakage through error messages
- */
-export class ValidationError extends Error {
-  constructor(message: string) {
-    // Only include safe error message, never user input
-    super(message);
-    this.name = 'ValidationError';
-  }
+function validateSearchQuery(params: unknown): ValidatedSearchQuery {
+  return SearchQuerySchema.parse(params);
 }
 ```
 
-### ✅ Good Pattern: Rate Limiting with Multiple Strategies
+### ✅ Good Pattern: Rate Limiting
 
 ```typescript
-/**
- * Multi-layer rate limiting for MCP tool requests
- * 
- * Rate limiting strategies:
- * 1. Fixed window (simple, prevents burst)
- * 2. Sliding window (accurate, prevents boundary gaming)
- * 3. Token bucket (flexible, allows burst within limits)
- * 4. IP-based limiting (prevents distributed abuse)
- * 
- * ISMS Policy: AC-002 (Access Control - Rate Limiting)
- * Compliance: NIST CSF PR.AC-4, CIS Control 13.3, OWASP API Security (API4:2023)
- * 
- * @security Defense: DoS attacks, brute force, resource exhaustion
- */
-export class RateLimiter {
-  private readonly fixedWindow = new Map<string, FixedWindowState>();
-  private readonly slidingWindow = new Map<string, number[]>();
-  
-  // Rate limit: 100 requests per 15 minutes
+class RateLimiter {
+  private requests = new Map<string, number[]>();
   private readonly MAX_REQUESTS = 100;
   private readonly WINDOW_MS = 15 * 60 * 1000;
-  
-  // Burst limit: 10 requests per 10 seconds
-  private readonly BURST_MAX = 10;
-  private readonly BURST_WINDOW_MS = 10 * 1000;
-  
-  /**
-   * Check rate limit for client
-   * Uses sliding window algorithm for accuracy
-   */
+
   async checkLimit(clientId: string): Promise<void> {
     const now = Date.now();
-    
-    // Check burst limit first (faster)
-    await this.checkBurstLimit(clientId, now);
-    
-    // Check sustained rate limit
-    await this.checkSustainedLimit(clientId, now);
-    
-    // Record this request
-    this.recordRequest(clientId, now);
-  }
-  
-  /**
-   * Check burst limit (short window)
-   * Prevents rapid-fire abuse
-   */
-  private async checkBurstLimit(clientId: string, now: number): Promise<void> {
-    const requests = this.slidingWindow.get(clientId) || [];
-    
-    const recentBurst = requests.filter(
-      timestamp => now - timestamp < this.BURST_WINDOW_MS
-    );
-    
-    if (recentBurst.length >= this.BURST_MAX) {
-      const oldestRequest = Math.min(...recentBurst);
-      const retryAfter = Math.ceil(
-        (oldestRequest + this.BURST_WINDOW_MS - now) / 1000
-      );
-      
-      // Log rate limit violation for monitoring
-      await this.logRateLimitViolation(clientId, 'burst', recentBurst.length);
-      
-      throw new RateLimitError(
-        'Burst rate limit exceeded. Slow down your requests.',
-        retryAfter
-      );
+    const recent = (this.requests.get(clientId) ?? []).filter(t => now - t < this.WINDOW_MS);
+    if (recent.length >= this.MAX_REQUESTS) {
+      throw new RateLimitError('Rate limit exceeded', Math.ceil((recent[0]! + this.WINDOW_MS - now) / 1000));
     }
-  }
-  
-  /**
-   * Check sustained rate limit (long window)
-   * Prevents sustained abuse
-   */
-  private async checkSustainedLimit(clientId: string, now: number): Promise<void> {
-    const requests = this.slidingWindow.get(clientId) || [];
-    
-    const recentRequests = requests.filter(
-      timestamp => now - timestamp < this.WINDOW_MS
-    );
-    
-    if (recentRequests.length >= this.MAX_REQUESTS) {
-      const oldestRequest = Math.min(...recentRequests);
-      const retryAfter = Math.ceil(
-        (oldestRequest + this.WINDOW_MS - now) / 1000
-      );
-      
-      // Log rate limit violation
-      await this.logRateLimitViolation(clientId, 'sustained', recentRequests.length);
-      
-      throw new RateLimitError(
-        `Rate limit exceeded. Maximum ${this.MAX_REQUESTS} requests per 15 minutes. Try again in ${retryAfter} seconds.`,
-        retryAfter
-      );
-    }
-  }
-  
-  /**
-   * Record request timestamp
-   */
-  private recordRequest(clientId: string, now: number): void {
-    const requests = this.slidingWindow.get(clientId) || [];
-    
-    // Add current request
-    requests.push(now);
-    
-    // Clean up old requests (memory management)
-    const filtered = requests.filter(
-      timestamp => now - timestamp < this.WINDOW_MS
-    );
-    
-    this.slidingWindow.set(clientId, filtered);
-  }
-  
-  /**
-   * Log rate limit violation for security monitoring
-   * ISMS Policy: IM-001 (Incident Management)
-   */
-  private async logRateLimitViolation(
-    clientId: string,
-    type: 'burst' | 'sustained',
-    requestCount: number
-  ): Promise<void> {
-    const event = {
-      timestamp: new Date().toISOString(),
-      eventType: 'RATE_LIMIT_VIOLATION',
-      severity: 'WARNING',
-      clientId: this.hashClientId(clientId), // Hash for privacy
-      limitType: type,
-      requestCount,
-      limit: type === 'burst' ? this.BURST_MAX : this.MAX_REQUESTS,
-      window: type === 'burst' ? this.BURST_WINDOW_MS : this.WINDOW_MS,
-    };
-    
-    // Log to audit system
-    await auditLogger.log(event);
-    
-    // Alert if sustained abuse detected
-    if (requestCount > this.MAX_REQUESTS * 2) {
-      await alerting.sendAlert({
-        type: 'SEVERE_RATE_LIMIT_VIOLATION',
-        clientId: this.hashClientId(clientId),
-        details: event,
-      });
-    }
-  }
-  
-  /**
-   * Hash client ID for privacy in logs
-   * Never log raw IP addresses or identifiers
-   */
-  private hashClientId(clientId: string): string {
-    return crypto
-      .createHash('sha256')
-      .update(clientId)
-      .digest('hex')
-      .substring(0, 16);
-  }
-  
-  /**
-   * Periodic cleanup of old data
-   */
-  startCleanup(): void {
-    setInterval(() => {
-      const now = Date.now();
-      
-      for (const [clientId, requests] of this.slidingWindow.entries()) {
-        const active = requests.filter(
-          timestamp => now - timestamp < this.WINDOW_MS
-        );
-        
-        if (active.length === 0) {
-          this.slidingWindow.delete(clientId);
-        } else {
-          this.slidingWindow.set(clientId, active);
-        }
-      }
-    }, 60 * 1000); // Clean up every minute
-  }
-}
-
-export class RateLimitError extends Error {
-  constructor(
-    message: string,
-    public readonly retryAfter: number
-  ) {
-    super(message);
-    this.name = 'RateLimitError';
+    recent.push(now);
+    this.requests.set(clientId, recent);
   }
 }
 ```
 
-### ✅ Good Pattern: Comprehensive Audit Logging
+### ✅ Good Pattern: Audit Logging
 
 ```typescript
-/**
- * Security audit logging for MCP server operations
- * 
- * Logs all security-relevant events:
- * - Authentication attempts (success/failure)
- * - Authorization checks (granted/denied)
- * - Input validation failures
- * - Rate limit violations
- * - Configuration changes
- * - Error conditions
- * 
- * ISMS Policy: IM-001 (Incident Management), AU-001 (Audit Logging)
- * Compliance: ISO 27001:2022 A.8.15, NIST CSF DE.AE-3, CIS Control 8.2
- * 
- * @security Immutable audit trail for forensics and compliance
- */
-export class AuditLogger {
-  private readonly logStream: fs.WriteStream;
-  
-  constructor(logPath: string) {
-    // Append-only log file for immutability
-    this.logStream = fs.createWriteStream(logPath, {
-      flags: 'a',
-      encoding: 'utf8',
-    });
-    
-    // Ensure logs are flushed on shutdown
-    process.on('SIGTERM', () => this.close());
-    process.on('SIGINT', () => this.close());
-  }
-  
-  /**
-   * Log security event
-   * All events are JSON formatted with consistent schema
-   */
-  async log(event: AuditEvent): Promise<void> {
-    const logEntry = {
-      timestamp: new Date().toISOString(),
-      eventId: crypto.randomUUID(),
-      eventType: event.type,
-      severity: event.severity,
-      actor: this.sanitizeActor(event.actor),
-      action: event.action,
-      resource: event.resource,
-      outcome: event.outcome,
-      metadata: event.metadata,
-      ipAddress: event.ipAddress ? this.hashIp(event.ipAddress) : undefined,
-    };
-    
-    // Write as newline-delimited JSON
-    return new Promise((resolve, reject) => {
-      this.logStream.write(
-        JSON.stringify(logEntry) + '\n',
-        (error) => {
-          if (error) {
-            // Critical: Audit logging failure
-            console.error('CRITICAL: Audit log write failed:', error);
-            reject(error);
-          } else {
-            resolve();
-          }
-        }
-      );
-    });
-  }
-  
-  /**
-   * Log authentication attempt
-   */
-  async logAuthentication(
-    actor: string,
-    success: boolean,
-    metadata?: Record<string, unknown>
-  ): Promise<void> {
-    await this.log({
-      type: 'AUTHENTICATION',
-      severity: success ? 'INFO' : 'WARNING',
-      actor,
-      action: 'authenticate',
-      resource: 'mcp-server',
-      outcome: success ? 'SUCCESS' : 'FAILURE',
-      metadata,
-    });
-  }
-  
-  /**
-   * Log authorization check
-   */
-  async logAuthorization(
-    actor: string,
-    action: string,
-    resource: string,
-    granted: boolean
-  ): Promise<void> {
-    await this.log({
-      type: 'AUTHORIZATION',
-      severity: granted ? 'INFO' : 'WARNING',
-      actor,
-      action,
-      resource,
-      outcome: granted ? 'GRANTED' : 'DENIED',
-    });
-  }
-  
-  /**
-   * Log input validation failure
-   */
-  async logValidationFailure(
-    actor: string,
-    tool: string,
-    errorType: string
-  ): Promise<void> {
-    await this.log({
-      type: 'INPUT_VALIDATION',
-      severity: 'WARNING',
-      actor,
-      action: 'validate_input',
-      resource: tool,
-      outcome: 'FAILURE',
-      metadata: { errorType },
-    });
-  }
-  
-  /**
-   * Log tool invocation
-   */
-  async logToolInvocation(
-    actor: string,
-    tool: string,
-    success: boolean,
-    duration?: number
-  ): Promise<void> {
-    await this.log({
-      type: 'TOOL_INVOCATION',
-      severity: 'INFO',
-      actor,
-      action: 'invoke_tool',
-      resource: tool,
-      outcome: success ? 'SUCCESS' : 'FAILURE',
-      metadata: { duration },
-    });
-  }
-  
-  /**
-   * Sanitize actor information
-   * Remove PII, hash identifiers
-   */
-  private sanitizeActor(actor?: string): string {
-    if (!actor) {
-      return 'anonymous';
-    }
-    
-    // Hash actor ID for privacy
-    return crypto
-      .createHash('sha256')
-      .update(actor)
-      .digest('hex')
-      .substring(0, 16);
-  }
-  
-  /**
-   * Hash IP address for privacy compliance
-   * GDPR requires minimizing PII in logs
-   */
-  private hashIp(ip: string): string {
-    return crypto
-      .createHash('sha256')
-      .update(ip)
-      .digest('hex')
-      .substring(0, 16);
-  }
-  
-  /**
-   * Close log stream gracefully
-   */
-  close(): void {
-    this.logStream.end();
-  }
-}
-
 interface AuditEvent {
   type: string;
   severity: 'INFO' | 'WARNING' | 'ERROR' | 'CRITICAL';
-  actor?: string;
+  actor: string;
   action: string;
   resource: string;
-  outcome: 'SUCCESS' | 'FAILURE' | 'GRANTED' | 'DENIED';
-  metadata?: Record<string, unknown>;
-  ipAddress?: string;
+  outcome: 'SUCCESS' | 'FAILURE';
+}
+
+async function logSecurityEvent(event: AuditEvent): Promise<void> {
+  const entry = { ...event, timestamp: new Date().toISOString(), eventId: crypto.randomUUID() };
+  await auditLogger.write(JSON.stringify(entry) + '\n');
 }
 ```
 
 ### ✅ Good Pattern: Secure Error Handling
 
 ```typescript
-/**
- * Secure error handling for MCP tools
- * 
- * Security principles:
- * - Never expose internal implementation details
- * - Never echo user input in error messages
- * - Log detailed errors internally, return generic externally
- * - Fail securely (deny by default)
- * 
- * ISMS Policy: SC-002 (Secure Coding Standards)
- * Compliance: OWASP Top 10 (A05:2021 - Security Misconfiguration)
- */
-export class SecureErrorHandler {
-  constructor(
-    private readonly auditLogger: AuditLogger
-  ) {}
-  
-  /**
-   * Handle error from MCP tool execution
-   * Returns safe error message to client, logs details internally
-   */
-  async handleToolError(
-    error: Error,
-    context: ErrorContext
-  ): Promise<ToolResponse> {
-    // Log full error details for debugging (internal only)
-    await this.auditLogger.log({
-      type: 'TOOL_ERROR',
-      severity: 'ERROR',
-      actor: context.actor,
-      action: context.action,
-      resource: context.resource,
-      outcome: 'FAILURE',
-      metadata: {
-        errorType: error.name,
-        errorMessage: error.message,
-        stackTrace: error.stack,
-      },
-    });
-    
-    // Return safe error message to client
-    const safeMessage = this.getSafeErrorMessage(error);
-    
-    return {
-      isError: true,
-      content: [{
-        type: 'text',
-        text: safeMessage,
-      }],
-    };
-  }
-  
-  /**
-   * Generate safe error message for client
-   * Never exposes internal details or user input
-   */
-  private getSafeErrorMessage(error: Error): string {
-    // Known safe error types (validation errors)
-    if (error instanceof ValidationError) {
-      return error.message; // Already safe
-    }
-    
-    if (error instanceof RateLimitError) {
-      return error.message; // Already safe
-    }
-    
-    if (error instanceof AuthorizationError) {
-      return 'Access denied. Insufficient permissions.';
-    }
-    
-    // Unknown errors: Generic message
-    // NEVER expose error.message, error.stack, or any internal details
-    return 'An error occurred while processing your request. Please try again later.';
-  }
+function getSafeErrorMessage(error: Error): string {
+  if (error instanceof ValidationError) return error.message;
+  if (error instanceof RateLimitError) return error.message;
+  return 'An error occurred. Please try again later.';
 }
 
-interface ErrorContext {
-  actor: string;
-  action: string;
-  resource: string;
-}
-
-export class AuthorizationError extends Error {
-  constructor(message: string = 'Access denied') {
-    super(message);
-    this.name = 'AuthorizationError';
-  }
+async function handleToolError(error: Error, context: ErrorContext): Promise<ToolResponse> {
+  await auditLogger.log({ type: 'TOOL_ERROR', severity: 'ERROR', ...context, outcome: 'FAILURE' });
+  return { isError: true, content: [{ type: 'text', text: getSafeErrorMessage(error) }] };
 }
 ```
 
-### ❌ Bad Pattern: No Input Validation
+### ❌ Anti-Patterns
 
-```typescript
-// Bad: Accepting user input without validation
-export async function searchDocuments(query: any): Promise<Results> {
-  // Direct use of unvalidated input - SQL injection vulnerability!
-  const sql = `SELECT * FROM documents WHERE title LIKE '%${query.keywords}%'`;
-  return await db.query(sql);
-}
-
-// Bad: Type assertion without validation
-export async function getDocument(params: any): Promise<Document> {
-  const id = params.documentId as string; // Unsafe cast!
-  return await europeanParliamentApi.getDocument(id);
-}
-
-// Bad: No length limits - DoS vulnerability
-export async function processText(text: string): Promise<string> {
-  // What if text is 1GB? Server crashes!
-  return text.toUpperCase();
-}
-```
-
-### ❌ Bad Pattern: Exposing Sensitive Information
-
-```typescript
-// Bad: Exposing internal error details
-export async function handleRequest(req: Request): Promise<Response> {
-  try {
-    return await processRequest(req);
-  } catch (error) {
-    // NEVER expose stack traces, error details, or internal paths!
-    return {
-      error: error.message,
-      stack: error.stack, // Exposes code structure!
-      file: error.fileName, // Exposes internal paths!
-    };
-  }
-}
-
-// Bad: Echoing user input in errors
-export function validateInput(input: string): void {
-  if (input.includes('<script>')) {
-    // NEVER echo user input - XSS vulnerability!
-    throw new Error(`Invalid input: ${input}`);
-  }
-}
-
-// Bad: Logging sensitive data
-export async function authenticate(username: string, password: string): Promise<boolean> {
-  console.log(`Authenticating user: ${username} with password: ${password}`);
-  // NEVER log credentials!
-  return checkCredentials(username, password);
-}
-```
-
-### ❌ Bad Pattern: No Rate Limiting
-
-```typescript
-// Bad: No rate limiting - DoS vulnerability
-export async function searchDocuments(query: SearchQuery): Promise<Results> {
-  // Anyone can make unlimited requests
-  // European Parliament API will block us!
-  // Server resources exhausted!
-  return await europeanParliamentApi.search(query);
-}
-
-// Bad: No burst protection
-export async function handleRequests(requests: Request[]): Promise<Response[]> {
-  // Processing 10,000 requests simultaneously - server crash!
-  return Promise.all(requests.map(r => processRequest(r)));
-}
-```
-
-### ❌ Bad Pattern: Secrets in Code
-
-```typescript
-// Bad: Hardcoded API key
-const API_KEY = 'sk-1234567890abcdef'; // NEVER commit secrets!
-
-// Bad: Credentials in config file (committed to Git)
-const config = {
-  database: {
-    host: 'db.example.com',
-    username: 'admin',
-    password: 'SuperSecret123', // Committed to Git history forever!
-  },
-};
-
-// Bad: API key in URL
-const url = `https://api.example.com/data?apikey=${API_KEY}`;
-// Logged in access logs, browser history, proxy logs!
-```
+- **Never use unvalidated input** in queries or operations — always parse through Zod first
+- **Never expose stack traces**, internal paths, or error details to clients
+- **Never echo user input** in error messages (XSS risk)
+- **Never commit API keys**, tokens, or credentials — use environment variables
+- **Never skip rate limiting** on public-facing endpoints
 
 ## References
 
-### Security Standards
 - [OWASP Top 10](https://owasp.org/www-project-top-ten/)
 - [OWASP API Security Top 10](https://owasp.org/API-Security/)
-- [OWASP ASVS](https://owasp.org/www-project-application-security-verification-standard/)
-- [CWE Top 25](https://cwe.mitre.org/top25/)
-
-### ISMS Policies
 - [Hack23 ISMS Public Repository](https://github.com/Hack23/ISMS-PUBLIC)
 - [SC-002 Secure Coding Standards](https://github.com/Hack23/ISMS-PUBLIC/blob/main/policies/SC-002.md)
-- [AC-002 Access Control Policy](https://github.com/Hack23/ISMS-PUBLIC/blob/main/policies/AC-002.md)
-- [IM-001 Incident Management](https://github.com/Hack23/ISMS-PUBLIC/blob/main/policies/IM-001.md)
-
-### Security Tools
-- [npm audit](https://docs.npmjs.com/cli/v8/commands/npm-audit) - Dependency vulnerability scanning
-- [Snyk](https://snyk.io/) - Continuous security monitoring
-- [OWASP Dependency-Check](https://owasp.org/www-project-dependency-check/)
-- [Semgrep](https://semgrep.dev/) - Static analysis security testing
-
-### Cryptography
-- [Node.js Crypto Module](https://nodejs.org/api/crypto.html)
-- [libsodium](https://libsodium.gitbook.io/) - Modern cryptography library
-- [TLS Best Practices](https://wiki.mozilla.org/Security/Server_Side_TLS)
-
-## Remember
-
-- **Never trust input**: Validate everything, sanitize always, encode appropriately
-- **Fail securely**: Default deny, safe error messages, no information leakage
-- **Defense in depth**: Multiple overlapping security controls
-- **Least privilege**: Minimal permissions, need-to-know basis
-- **Audit everything**: Log security events, monitor for anomalies
-- **Rate limit aggressively**: Protect against abuse and DoS attacks
-- **Encrypt always**: TLS 1.3+ for transit, AES-256 for at rest
-- **Secure by default**: All features secure unless explicitly configured otherwise
-- **No secrets in code**: Use environment variables, secret management systems
-- **Update dependencies**: Patch vulnerabilities quickly, scan continuously
-- **Assume breach**: Limit blast radius, segment networks, monitor for indicators
-- **Document security**: Reference ISMS policies, explain threat mitigations
-- **Test security controls**: Write tests for auth, authz, validation, encryption
-- **European Parliament data**: Respect data protection regulations, handle sensitively
-- **MCP protocol**: Validate tool schemas strictly, sanitize responses

--- a/.github/skills/testing-mcp-tools/SKILL.md
+++ b/.github/skills/testing-mcp-tools/SKILL.md
@@ -1,42 +1,30 @@
 ---
 name: testing-mcp-tools
-description: Testing patterns for MCP tools, integration tests, mocking European Parliament API, and achieving 80%+ coverage
+description: "Writes unit and integration tests for MCP tool handlers using Vitest, mocks European Parliament API responses, validates Zod schemas, and enforces 80%+ line coverage. Use when writing tests for MCP tools, improving test coverage, mocking the EP API, or debugging test failures."
 license: MIT
 ---
 
 # Testing MCP Tools Skill
 
-## Context
-
-This skill applies when:
-- Writing unit tests for MCP tools, resources, and prompts
-- Testing European Parliament API integrations
-- Mocking external API calls
-- Writing integration tests for MCP server
-- Achieving 80%+ code coverage target
-- Testing error handling and edge cases
-- Validating Zod schema validation
-- Performance testing for response times
-- Testing GDPR compliance features
-
-This project uses Vitest as the test framework with a coverage target of 80% line coverage and 70% branch coverage.
-
 ## Rules
 
-1. **Test All MCP Handlers**: Every tool, resource, and prompt must have tests
-2. **Mock External APIs**: Never call real European Parliament API in tests
-3. **Test Input Validation**: Verify Zod schema validation with valid/invalid inputs
-4. **Test Error Paths**: Test all error scenarios and exception handling
-5. **Achieve Coverage Target**: 80% line coverage, 70% branch coverage minimum
-6. **Use Descriptive Names**: Test names should describe what is being tested
-7. **Arrange-Act-Assert**: Structure tests with clear AAA pattern
-8. **Test Response Structure**: Verify MCP-compliant response formats
-9. **Test Edge Cases**: Empty inputs, max lengths, boundary conditions
-10. **Integration Tests**: Test full MCP request/response cycle
+1. **Mock External APIs**: Never call the real European Parliament API in tests — use the mock factory pattern
+2. **Test MCP Response Structure**: Every handler test must verify `{ content: [{ type: "text", text }] }` format
+3. **Coverage Target**: 80% line coverage, 70% branch coverage minimum
+4. **Test Input Validation**: Verify Zod schema rejects invalid inputs (bad country codes, out-of-range limits, XSS payloads)
+5. **Integration Tests**: Test the full MCP request/response cycle — `tools/list` and `tools/call` through the server
+
+## Workflow
+
+1. Run `vitest --coverage` to identify uncovered MCP handlers
+2. For each uncovered handler, write tests: valid input → expected response, invalid input → Zod rejection, API error → safe error message
+3. Mock EP API calls using the mock factory pattern (see example below)
+4. Verify MCP-compliant response structure in every test: `{ content: [{ type: "text", text }] }`
+5. Run `vitest --coverage` again — confirm 80% line / 70% branch thresholds pass
 
 ## Examples
 
-### ✅ Good Pattern: Testing MCP Tool
+### Testing MCP Tool
 
 ```typescript
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -44,11 +32,10 @@ import { handleSearchMEPs } from './search-meps';
 
 describe('MCP Tool: search_meps', () => {
   beforeEach(() => {
-    // Reset mocks before each test
     vi.clearAllMocks();
   });
-  
-  it('should validate input schema', async () => {
+
+  it('should validate input schema and reject invalid arguments', async () => {
     const invalidRequest = {
       params: {
         name: 'search_meps',
@@ -58,133 +45,75 @@ describe('MCP Tool: search_meps', () => {
         },
       },
     };
-    
+
     await expect(handleSearchMEPs(invalidRequest)).rejects.toThrow();
   });
-  
+
   it('should return MCP-compliant response structure', async () => {
-    // Mock API
     vi.mock('./api', () => ({
       searchMEPs: vi.fn().mockResolvedValue([
         { id: 1, fullName: 'Test MEP', country: 'DE' },
       ]),
     }));
-    
+
     const validRequest = {
       params: {
         name: 'search_meps',
-        arguments: {
-          country: 'DE',
-          limit: 10,
-        },
+        arguments: { country: 'DE', limit: 10 },
       },
     };
-    
+
     const response = await handleSearchMEPs(validRequest);
-    
+
     // Verify MCP response structure
     expect(response).toHaveProperty('content');
-    expect(Array.isArray(response.content)).toBe(true);
     expect(response.content[0]).toHaveProperty('type', 'text');
     expect(response.content[0]).toHaveProperty('text');
-    
-    // Verify response content
+
     const data = JSON.parse(response.content[0].text);
-    expect(data).toHaveProperty('count');
     expect(data).toHaveProperty('meps');
     expect(Array.isArray(data.meps)).toBe(true);
   });
-  
-  it('should handle API errors gracefully', async () => {
-    // Mock API failure
+
+  it('should handle API errors without exposing internals', async () => {
     vi.mock('./api', () => ({
       searchMEPs: vi.fn().mockRejectedValue(new Error('API Error')),
     }));
-    
+
     const request = {
       params: {
         name: 'search_meps',
         arguments: { country: 'DE' },
       },
     };
-    
+
     await expect(handleSearchMEPs(request)).rejects.toThrow('Failed to search MEPs');
-    // Verify internal error is NOT exposed
-  });
-  
-  it('should reject invalid characters in country code', async () => {
-    const request = {
-      params: {
-        name: 'search_meps',
-        arguments: {
-          country: '<script>alert("xss")</script>',
-        },
-      },
-    };
-    
-    await expect(handleSearchMEPs(request)).rejects.toThrow();
-  });
-  
-  it('should apply default values for optional parameters', async () => {
-    vi.mock('./api', () => ({
-      searchMEPs: vi.fn().mockResolvedValue([]),
-    }));
-    
-    const request = {
-      params: {
-        name: 'search_meps',
-        arguments: {
-          country: 'DE',
-          // limit not provided - should default to 20
-        },
-      },
-    };
-    
-    await handleSearchMEPs(request);
-    
-    const apiMock = await import('./api');
-    expect(apiMock.searchMEPs).toHaveBeenCalledWith(
-      expect.objectContaining({ limit: 20 })
-    );
   });
 });
 ```
 
-### ✅ Good Pattern: Mocking European Parliament API
+### Mocking European Parliament API
 
 ```typescript
 import { vi } from 'vitest';
 
-/**
- * Mock European Parliament API responses
- */
 export function mockEPAPI() {
-  // Mock fetch globally
   global.fetch = vi.fn();
-  
+
   return {
     mockMEP(id: number, data: Partial<MEP> = {}) {
       (global.fetch as any).mockResolvedValueOnce(
         new Response(JSON.stringify({
-          id,
-          fullName: 'Test MEP',
-          country: 'DE',
-          partyGroup: 'PPE',
-          active: true,
-          ...data,
-        }), {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' },
-        })
+          id, fullName: 'Test MEP', country: 'DE',
+          partyGroup: 'PPE', active: true, ...data,
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } })
       );
     },
-    
+
     mockAPIError(status: number = 500) {
-      (global.fetch as any).mockResolvedValueOnce(
-        new Response(null, { status })
-      );
+      (global.fetch as any).mockResolvedValueOnce(new Response(null, { status }));
     },
-    
+
     mockRateLimit(retryAfter: number = 60) {
       (global.fetch as any).mockResolvedValueOnce(
         new Response(null, {
@@ -195,208 +124,13 @@ export function mockEPAPI() {
     },
   };
 }
-
-// Usage in tests
-describe('EP API Integration', () => {
-  it('should handle rate limiting', async () => {
-    const api = mockEPAPI();
-    
-    // First call returns rate limit
-    api.mockRateLimit(1);
-    
-    // Second call succeeds
-    api.mockMEP(12345);
-    
-    const mep = await fetchMEPWithRetry(12345);
-    
-    expect(mep.id).toBe(12345);
-    expect(fetch).toHaveBeenCalledTimes(2);
-  });
-});
-```
-
-### ✅ Good Pattern: Testing Zod Schemas
-
-```typescript
-import { describe, it, expect } from 'vitest';
-import { MEPSchema } from './schemas';
-
-describe('MEPSchema', () => {
-  it('should validate valid MEP data', () => {
-    const validMEP = {
-      id: 12345,
-      fullName: 'Jane Doe',
-      country: 'DE',
-      partyGroup: 'PPE',
-      active: true,
-      termStart: '2019-07-02',
-      committees: [],
-    };
-    
-    const result = MEPSchema.parse(validMEP);
-    expect(result.id).toBe(12345);
-  });
-  
-  it('should reject invalid country code', () => {
-    const invalidMEP = {
-      id: 12345,
-      fullName: 'Jane Doe',
-      country: 'USA', // Not EU country
-      partyGroup: 'PPE',
-      active: true,
-      termStart: '2019-07-02',
-    };
-    
-    expect(() => MEPSchema.parse(invalidMEP)).toThrow();
-  });
-  
-  it('should apply default values', () => {
-    const mepWithoutDefaults = {
-      id: 12345,
-      fullName: 'Jane Doe',
-      country: 'DE',
-      partyGroup: 'PPE',
-      active: true,
-      termStart: '2019-07-02',
-      // committees not provided
-    };
-    
-    const result = MEPSchema.parse(mepWithoutDefaults);
-    expect(result.committees).toEqual([]);
-  });
-  
-  it('should transform and normalize data', () => {
-    const mepWithWhitespace = {
-      id: 12345,
-      fullName: '  Jane Doe  ',
-      country: 'DE',
-      partyGroup: 'PPE',
-      active: true,
-      termStart: '2019-07-02',
-    };
-    
-    const result = MEPSchema.parse(mepWithWhitespace);
-    expect(result.fullName).toBe('Jane Doe'); // Trimmed
-  });
-});
-```
-
-### ✅ Good Pattern: Integration Tests
-
-```typescript
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { EuropeanParliamentMCPServer } from './server';
-
-describe('MCP Server Integration', () => {
-  let server: EuropeanParliamentMCPServer;
-  
-  beforeAll(async () => {
-    server = new EuropeanParliamentMCPServer();
-    await server.start();
-  });
-  
-  afterAll(async () => {
-    await server.shutdown();
-  });
-  
-  it('should list available tools', async () => {
-    const request = {
-      jsonrpc: '2.0',
-      id: 1,
-      method: 'tools/list',
-    };
-    
-    const response = await server.handleRequest(request);
-    
-    expect(response.result).toHaveProperty('tools');
-    expect(Array.isArray(response.result.tools)).toBe(true);
-    expect(response.result.tools.length).toBeGreaterThan(0);
-  });
-  
-  it('should execute tool and return result', async () => {
-    const request = {
-      jsonrpc: '2.0',
-      id: 1,
-      method: 'tools/call',
-      params: {
-        name: 'search_meps',
-        arguments: {
-          country: 'DE',
-          limit: 5,
-        },
-      },
-    };
-    
-    const response = await server.handleRequest(request);
-    
-    expect(response.result).toHaveProperty('content');
-    expect(Array.isArray(response.result.content)).toBe(true);
-  });
-});
-```
-
-### ✅ Good Pattern: Performance Testing
-
-```typescript
-import { describe, it, expect } from 'vitest';
-import { performance } from 'perf_hooks';
-
-describe('Performance Tests', () => {
-  it('should respond to MEP requests in <200ms', async () => {
-    const startTime = performance.now();
-    
-    await getMEP(12345);
-    
-    const duration = performance.now() - startTime;
-    expect(duration).toBeLessThan(200);
-  });
-  
-  it('should achieve >80% cache hit rate', async () => {
-    // Warm cache
-    await getCachedMEP(12345);
-    
-    // Make 100 requests
-    for (let i = 0; i < 100; i++) {
-      await getCachedMEP(12345);
-    }
-    
-    const stats = getCacheStats('mep');
-    const hitRate = stats.hits / (stats.hits + stats.misses);
-    
-    expect(hitRate).toBeGreaterThan(0.8);
-  });
-});
 ```
 
 ## Anti-Patterns
 
-### ❌ Bad: Calling Real API
-```typescript
-// NEVER - slow and unreliable!
-it('should fetch MEP', async () => {
-  const mep = await fetch('https://data.europarl.europa.eu/api/v2/meps/12345');
-  expect(mep).toBeDefined();
-});
-```
-
-### ❌ Bad: No Assertions
-```typescript
-// NEVER - test doesn't verify anything!
-it('should process MEP', async () => {
-  await processMEP(12345);
-  // No assertions!
-});
-```
-
-### ❌ Bad: Testing Implementation
-```typescript
-// NEVER - test behavior, not implementation!
-it('should call internal function', async () => {
-  const spy = vi.spyOn(internal, 'helperFunction');
-  await publicAPI();
-  expect(spy).toHaveBeenCalled(); // Testing internals!
-});
-```
+- Never call the real EP API in tests — use the mock factory
+- Always assert on response structure, not just that the call succeeded
+- Test behavior (inputs → outputs), not internal implementation details
 
 ## Coverage Requirements
 


### PR DESCRIPTION
Hey @pethers 👋

62 MCP tools, SLSA Level 3 provenance, and 40 Copilot skills governing everything from AI development policy to C4 architecture documentation. You've built a proper intelligence platform here, not just an API wrapper. The fact that you're dogfooding your own ISMS security policy through dedicated Copilot skills shows a level of rigor you rarely see in open-source MCP servers. We tightened up a few of the skill files to sharpen their trigger accuracy and structure.

I ran your skills through `tessl skill review` at work and found some targeted improvements. Here's the full before/after:

<img width="1312" height="910" alt="score_card" src="https://github.com/user-attachments/assets/427cf6a6-7b0c-4d24-b324-d108dba02db6" />


<details>
<summary>Changes summary</summary>

**testing-mcp-tools (+40%)** — the biggest win:
- Rewrote description with concrete actions, Vitest/EP API trigger terms, and a "Use when..." clause
- Reduced from 425 lines to 158 lines (63% reduction) by removing standard testing patterns Claude already knows
- Trimmed rules from 10 to 5 project-specific rules (removed AAA pattern, descriptive names, etc.)
- Added a 5-step testing workflow with coverage verification checkpoints
- Kept only the 2 most valuable examples: MCP tool tests and EP API mock factory
- Condensed anti-patterns from code blocks to bullet points

**gdpr-compliance (+35%)**:
- Added "Use when..." clause with trigger terms: PII, DPIA, anonymization, data subject requests, cache retention
- Removed explanatory paragraph about what GDPR is (Claude already knows)
- Added 6-step implementation workflow with verification checkpoint
- Trimmed redundant code comments across all examples
- Condensed anti-patterns from 3 code blocks to 3 bullet points

**security-by-design (+35%)**:
- Reduced from 928 lines to 126 lines (86% reduction — was over the 500-line validation threshold)
- Rewrote description with concrete actions and "Use when..." clause
- Trimmed rules from 15 to 8 actionable, MCP-specific rules
- Replaced 4 full class implementations (~660 lines) with concise pattern snippets (10-15 lines each)
- Added 6-step security workflow: validate → rate limit → authorize → execute → sanitize → audit
- Removed "Remember" section that duplicated the rules verbatim
- Condensed anti-patterns and trimmed references to essential links only

**european-parliament-api (+27%)**:
- Added "Use when..." clause with trigger terms: EP Open Data Portal, Europarl endpoints, EU parliamentary data
- Added 5-step integration workflow: init client → rate limiter → caches → request/validate/attribute → cache lifecycle
- Condensed anti-patterns from code blocks to bullet points
- Trimmed redundant code comments

**mcp-server-development (+27%)**:
- Added "Use when..." clause with trigger terms: MCP tools, MCP server, Model Context Protocol integrations
- Trimmed rules from 10 to 6 MCP-specific rules (removed generic "Use Type Safety", "Write comprehensive tests")
- Added 5-step MCP tool creation workflow with verification step
- Removed redundant MCP explanation paragraph from Context section
- Condensed anti-patterns from code blocks to bullet points

</details>

Honest disclosure. I work at @tesslio where we build tooling around skills like these. Not a pitch - just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at [this Tessl guide](https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me - [@yogesh-tessl](https://github.com/yogesh-tessl) - if you hit any snags.

Thanks in advance 🙏
