### PR TITLE
Fix for Comparison between inconvertible types

### DIFF
--- a/tests/helpers/testUtils.ts
+++ b/tests/helpers/testUtils.ts
@@ -54,7 +54,7 @@ function isRateLimitOrNetworkError(error: unknown): boolean {
       return true;
     }
     // Also check statusCode (APIError) or httpStatus (ToolError) for 408, 429, 503
-    if (typeof current === 'object' && current !== null) {
+    if (typeof current === 'object') {
       const code = 'statusCode' in current
         ? (current as { statusCode?: unknown }).statusCode
         : 'httpStatus' in current


### PR DESCRIPTION
To fix this without changing functionality, simplify the object-guard on line 57 by removing `&& current !== null`, since null has already been excluded by the `for` loop condition on line 51.

**What to change (single best fix):**
- File: `tests/helpers/testUtils.ts`
- Region: `isRateLimitOrNetworkError`, the `if` guarding status extraction.
- Replace:
  - `if (typeof current === 'object' && current !== null) {`
- With:
  - `if (typeof current === 'object') {`

No imports, new methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._