### PR TITLE
Fix for Comparison between inconvertible types

### DIFF
--- a/scripts/generate-stats.ts
+++ b/scripts/generate-stats.ts
@@ -431,7 +431,7 @@ function extractRecordDate(item: Record<string, unknown>): string | null {
   ] as const;
   for (const field of nestedDateFields) {
     const nested: unknown = item[field];
-    if (nested && typeof nested === 'object' && nested !== null) {
+    if (nested && typeof nested === 'object') {
       const value = (nested as Record<string, unknown>)['@value'];
       if (typeof value === 'string' && DATE_PATTERN.test(value)) {
         return value.substring(0, 10);


### PR DESCRIPTION
To fix this without changing functionality, simplify the conditional at `scripts/generate-stats.ts` in `extractRecordDate` by removing the redundant null comparison.

Best single fix:
- In the loop over `nestedDateFields`, change:
  - `if (nested && typeof nested === 'object' && nested !== null) {`
  - to:
  - `if (nested && typeof nested === 'object') {`

This preserves runtime behavior, keeps type narrowing valid for the cast to `Record<string, unknown>`, and resolves the CodeQL complaint about comparing with `null` in a context where `null` is already excluded.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._