### PR TITLE
Simplify permissions in copilot-setup-steps.yml

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -37,17 +37,6 @@ jobs:
     # Copilot will be given its own token for its operations.
     permissions:
       contents: read
-      actions: read
-      attestations: read
-      checks: read
-      deployments: read
-      issues: write
-      models: read
-      discussions: read
-      pages: read
-      pull-requests: write
-      security-events: read
-      statuses: read
 
     # Steps run before the agent starts working
     steps:


### PR DESCRIPTION
Removed unnecessary permissions from the workflow configuration.

By submitting a request, you represent that you have the right to license
your contribution to the community, and agree that your contributions are
licensed under the [The Apache Software License, Version 2.0](LICENSE.md).

---

## Checklist

- [ ] Tests pass locally (`npm run test:unit`, `npm run test:integration`).
- [ ] No new lint or knip errors (`npm run lint`, `npm run knip`).
- [ ] Documentation updated (README, INTEGRATION_TESTING.md, CONTRIBUTING.md, JSDoc) where behaviour changed.

### OSINT changes only

Tick **both** boxes when any file under `tests/integration/osint/__snapshots__/` or `tests/fixtures/osint/` is modified by this PR:

- [ ] **OSINT snapshot refresh acknowledged.** I have reviewed every diff under `tests/integration/osint/__snapshots__/`, confirmed the methodology change is intentional, and regenerated the snapshots with `npm run test:osint:snapshots -- -u`.
- [ ] **Methodology change documented.** The justification for the scoring/classification/attribution change is described in this PR's body and (where appropriate) in `INTEGRATION_TESTING.md` § "OSINT QA Harness — Golden Snapshots".

See `CONTRIBUTING.md` § "Refreshing OSINT golden snapshots" for the full procedure and reviewer guidance.
